### PR TITLE
User creation should use skel files

### DIFF
--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -2,7 +2,9 @@ user = node[:ebs_backups][:user]
 group = node[:ebs_backups][:group]
 home_dir = "/home/#{user}"
 
-group group
+group group do
+  append true
+end
 user user do
   home home_dir
   gid group

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -2,14 +2,16 @@ user = node[:ebs_backups][:user]
 group = node[:ebs_backups][:group]
 home_dir = "/home/#{user}"
 
-group group do
-  append true
-end
+
 user user do
   home home_dir
-  gid group
   system true
   supports :manage_home => true
+end
+
+group group do
+  members user
+  append true
 end
 
 directory node[:ebs_backups][:log_dir] do

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -1,21 +1,13 @@
 user = node[:ebs_backups][:user]
 group = node[:ebs_backups][:group]
-
 home_dir = "/home/#{user}"
 
+group group
 user user do
   home home_dir
+  gid group
   system true
-end
-
-group group do
-  members user
-end
-
-directory home_dir do
-  owner user
-  group group
-  mode 0700
+  supports :manage_home => true
 end
 
 directory node[:ebs_backups][:log_dir] do


### PR DESCRIPTION
Change user creation to make use of Chef's `manage_home` which creates the Linux system user with appropriate skeleton files.